### PR TITLE
apply fixes from https://github.com/kubernetes/kubernetes/pull/111934

### DIFF
--- a/cmd/applyconfiguration-gen/args/args.go
+++ b/cmd/applyconfiguration-gen/args/args.go
@@ -50,8 +50,9 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 	customArgs := &CustomArgs{
 		ExternalApplyConfigurations: map[types.Name]string{
 			// Always include TypeMeta and ObjectMeta. They are sufficient for the vast majority of use cases.
-			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "TypeMeta"}:   "k8s.io/client-go/applyconfigurations/meta/v1",
-			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ObjectMeta"}: "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "TypeMeta"}:       "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ObjectMeta"}:     "k8s.io/client-go/applyconfigurations/meta/v1",
+			{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "OwnerReference"}: "k8s.io/client-go/applyconfigurations/meta/v1",
 		},
 	}
 	genericArgs.CustomArgs = customArgs


### PR DESCRIPTION
This is used to generate https://github.com/openshift/client-go/pull/221 and we need the client very quickly.  We expect to re-collapse once we backport fixes.